### PR TITLE
Switch MySQL character set to utf8mb4

### DIFF
--- a/api/sql/reset-test-db.sql
+++ b/api/sql/reset-test-db.sql
@@ -1,2 +1,2 @@
 DROP DATABASE IF EXISTS `uberlike_test`;
-CREATE DATABASE IF NOT EXISTS `uberlike_test` COLLATE utf8_unicode_ci;
+CREATE DATABASE IF NOT EXISTS `uberlike_test` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/api/sql/uberlike.sql
+++ b/api/sql/uberlike.sql
@@ -21,21 +21,21 @@
 
 DROP TABLE IF EXISTS `rider`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `rider` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `uuid` varchar(36) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `lastname` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `firstname` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `phone` varchar(15) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `password` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `uuid` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `lastname` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `firstname` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `phone` varchar(15) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `password` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT '0000-00-00 00:00:00',
   PRIMARY KEY (`id`),
   UNIQUE KEY `rider_uuid_uindex` (`uuid`),
   UNIQUE KEY `rider_phone_uindex` (`phone`),
   UNIQUE KEY `rider_email_uindex` (`email`)
-) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/api/src/config/database.js
+++ b/api/src/config/database.js
@@ -11,7 +11,8 @@ const conn = mysql.createConnection({
     user: db().user,
     password: db().password,
     database: db().database,
-    port: db().port
+    port: db().port,
+    charset: 'utf8mb4'
 });
 
 conn.connect((err) => {


### PR DESCRIPTION
utf8mb4 collation is a far more better implementation of unicode. It allows you to use emoji in your database storage collections for example. See more in the web.