### PR TITLE
Optimise mysql model

### DIFF
--- a/api/sql/uberlike.sql
+++ b/api/sql/uberlike.sql
@@ -31,10 +31,9 @@ CREATE TABLE `device` (
   `revoked` tinyint(1) DEFAULT '0',
   `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT '0000-00-00 00:00:00',
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `device_uuid_uindex` (`uuid`),
+  PRIMARY KEY (`id`, `uuid`),
   UNIQUE KEY `device_refresh_token_uindex` (`refresh_token`)
-) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -53,11 +52,10 @@ CREATE TABLE `rider` (
   `email` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `password` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT '0000-00-00 00:00:00',
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `rider_uuid_uindex` (`uuid`),
+  PRIMARY KEY (`id`, `uuid`),
   UNIQUE KEY `rider_phone_uindex` (`phone`),
   UNIQUE KEY `rider_email_uindex` (`email`)
-) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 


### PR DESCRIPTION
I did a couple of changes to your sql model:

- Change the engine to InnoDB:

InnoDB has row-level locking, MyISAM can only do full table-level locking. InnoDB has better crash recovery and implements transactions, foreign keys and relationship constraints, MyISAM does not.

- Set the auto_increment to 0:

Well, no need to write a 10k line explanation on this one 😁 

- Set the primary key to (id, uuid):

> Primary keys and unique keys are similar. A primary key is a column, or a combination of columns, that can uniquely identify a row. It is a special case of unique key.

Thus, putting the uuid in the primary key, you add unique identifier to your table. Your rows will be identified by the (id, uuid) couple.